### PR TITLE
Fix two bugs preventing Claude Teams from working

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -8,8 +8,11 @@ if [ -z "$ZELLIJ" ]; then
     return 1 2>/dev/null || exit 1
 fi
 
-# Guard: don't double-activate
+# Guard: don't double-activate — but always re-ensure PATH priority.
+# Child shells inherit ZELLIJ_TMUX_SHIM_ACTIVE but rebuild PATH from
+# shell config, pushing the shim behind other entries (brew, cargo, etc.).
 if [ -n "$ZELLIJ_TMUX_SHIM_ACTIVE" ]; then
+    export PATH="${ZELLIJ_TMUX_SHIM_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/zellij-tmux-shim}/bin:${PATH}"
     return 0 2>/dev/null || exit 0
 fi
 

--- a/bin/tmux
+++ b/bin/tmux
@@ -335,7 +335,9 @@ split-window)
     zellij_args=(action new-pane --close-on-exit -d "$sw_direction")
 
     # Launch the wrapper in a new zellij pane.
-    zellij "${zellij_args[@]}" -- "${SHIM_DIR}/bin/zellij-pane-wrapper" "$STATE_DIR" "$SHIM_DIR" "$NEW_PANE_ID" &
+    # Redirect stdout/stderr — zellij prints the new pane ID (e.g. "terminal_25")
+    # which would leak into our output and corrupt the pane ID returned via -P.
+    zellij "${zellij_args[@]}" -- "${SHIM_DIR}/bin/zellij-pane-wrapper" "$STATE_DIR" "$SHIM_DIR" "$NEW_PANE_ID" > /dev/null 2>&1 &
 
     # Wait for wrapper to signal readiness (creates .ready sentinel)
     if ! wait_for_ready "$PANE_KEY"; then
@@ -607,7 +609,7 @@ new-window)
         zellij_args+=(-n "$nw_name")
     fi
 
-    zellij "${zellij_args[@]}" -- "${SHIM_DIR}/bin/zellij-pane-wrapper" "$STATE_DIR" "$SHIM_DIR" "$NEW_PANE_ID" &
+    zellij "${zellij_args[@]}" -- "${SHIM_DIR}/bin/zellij-pane-wrapper" "$STATE_DIR" "$SHIM_DIR" "$NEW_PANE_ID" > /dev/null 2>&1 &
 
     if ! wait_for_ready "$PANE_KEY"; then
         log_debug "new-window: pane ${NEW_PANE_ID} failed to become ready"


### PR DESCRIPTION
## Summary

- **PATH priority lost in child shells**: The double-activation guard in `activate.sh` returned early without re-prepending the shim to PATH. Child shells inherit `ZELLIJ_TMUX_SHIM_ACTIVE` but rebuild PATH from shell config (brew, cargo, bun, etc.), pushing the shim behind the real tmux binary — causing "Could not determine current tmux pane/window" errors.
- **Zellij stdout leaked into pane ID**: `zellij action new-pane` prints the new pane's Zellij ID (e.g. `terminal_25`) to stdout, which mixed with the shim's `-P` output. Claude Code received `terminal_25\n%7` instead of `%7`, causing `send-keys` to fail pane key validation.

## Test plan

- [ ] Activate shim in Zellij, open a new pane, verify `which tmux` returns the shim path (not `/opt/homebrew/bin/tmux`)
- [ ] Run Claude Code with Agent Teams / `TeamCreate` and confirm agents spawn successfully
- [ ] Check `$ZELLIJ_TMUX_SHIM_STATE/shim.log` for clean `send-keys` delivery (no "invalid pane key" errors)
- [ ] Verify multiple agents stack correctly in vertical layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)