### PR TITLE
Harden zellij tmux shim state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Agent panes are named after their role and stack vertically on the right.
 
 ## Requirements
 
-- **Zellij** 0.40+ (tested on 0.43.1)
+- **Zellij** 0.40+ (tested on 0.44.1)
 - **Bash** 3.2+ (ships with macOS; Linux has 4+)
 - **Claude Code** with Agent Teams support
 
@@ -103,7 +103,7 @@ bash install.sh --uninstall
 - **Vertical layout** — the first agent splits right; subsequent agents stack below it automatically
 - **Session isolation** — state is scoped by `ZELLIJ_SESSION_NAME`, so multiple Zellij sessions don't collide
 - **Tab isolation** — agent teams in different tabs within the same session are tracked independently via `.group` files
-- **Focus management** — focus chains through agents during creation, with `move-focus right` ensuring correct placement even if you click back to main between spawns
+- **Focus management** — focus chains through agents during creation, and late `send-keys` delivery focuses the recorded Zellij pane before writing
 
 ## How It Works
 
@@ -170,6 +170,14 @@ Ensure the shim is activated in your shell (check `echo $ZELLIJ_TMUX_SHIM_ACTIVE
 export ZELLIJ_TMUX_SHIM_DEBUG=1
 # Use Claude Code normally, then inspect:
 cat "${ZELLIJ_TMUX_SHIM_STATE}/shim.log"
+```
+
+## Development
+
+```bash
+bash tests/run.sh
+bash -n activate.sh deactivate.sh install.sh bin/tmux bin/zellij-pane-wrapper tests/run.sh
+shellcheck activate.sh deactivate.sh install.sh bin/tmux bin/zellij-pane-wrapper tests/run.sh
 ```
 
 ## Known Limitations

--- a/activate.sh
+++ b/activate.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2317
 # Source this file to activate the zellij-tmux-shim.
 # Usage: source activate.sh
 
 # Guard: only activate inside zellij
-if [ -z "$ZELLIJ" ]; then
+if [ -z "${ZELLIJ:-}" ]; then
     echo "zellij-tmux-shim: not inside zellij, skipping activation" >&2
     return 1 2>/dev/null || exit 1
 fi
@@ -11,8 +12,13 @@ fi
 # Guard: don't double-activate — but always re-ensure PATH priority.
 # Child shells inherit ZELLIJ_TMUX_SHIM_ACTIVE but rebuild PATH from
 # shell config, pushing the shim behind other entries (brew, cargo, etc.).
-if [ -n "$ZELLIJ_TMUX_SHIM_ACTIVE" ]; then
-    export PATH="${ZELLIJ_TMUX_SHIM_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/zellij-tmux-shim}/bin:${PATH}"
+if [ -n "${ZELLIJ_TMUX_SHIM_ACTIVE:-}" ]; then
+    _shim_bin="${ZELLIJ_TMUX_SHIM_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/zellij-tmux-shim}/bin"
+    _first_path_component="${PATH%%:*}"
+    if [ "$_first_path_component" != "$_shim_bin" ]; then
+        export PATH="${_shim_bin}:${PATH}"
+    fi
+    unset _shim_bin _first_path_component
     return 0 2>/dev/null || exit 0
 fi
 
@@ -24,7 +30,13 @@ ZELLIJ_TMUX_SHIM_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/zellij-tmux-shim"
 # Scoped by ZELLIJ_SESSION_NAME so multiple zellij sessions don't collide.
 _runtime_base="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}"
 _shim_root="${_runtime_base}/zellij-tmux-shim-$(id -u)"
-ZELLIJ_TMUX_SHIM_STATE="${_shim_root}/${ZELLIJ_SESSION_NAME:-default}"
+ZELLIJ_TMUX_SHIM_ROOT="$_shim_root"
+_session_raw="${ZELLIJ_SESSION_NAME:-default}"
+_session_slug=$(printf '%s' "$_session_raw" | tr -c '[:alnum:]_-' '-' | sed 's/^-*//; s/-*$//; s/--*/-/g' | cut -c 1-48)
+[ -n "$_session_slug" ] || _session_slug="default"
+_session_hash=$(printf '%s' "$_session_raw" | cksum | awk '{print $1}')
+ZELLIJ_TMUX_SHIM_STATE="${_shim_root}/${_session_slug}-${_session_hash}"
+unset _session_raw _session_slug _session_hash
 unset _runtime_base
 
 # Save real tmux path before we shadow it
@@ -44,6 +56,7 @@ export TMUX_PANE="%0"
 
 # Export state dir for shim scripts
 export ZELLIJ_TMUX_SHIM_DIR
+export ZELLIJ_TMUX_SHIM_ROOT
 export ZELLIJ_TMUX_SHIM_STATE
 
 # Initialize state directory — this is the security keystone.
@@ -55,8 +68,16 @@ if [ -L "$_shim_root" ]; then
     unset _shim_root
     return 1 2>/dev/null || exit 1
 fi
-mkdir -p "$_shim_root"
-chmod 700 "$_shim_root"
+if ! mkdir -p "$_shim_root"; then
+    echo "zellij-tmux-shim: ERROR: failed to create state root" >&2
+    unset _shim_root
+    return 1 2>/dev/null || exit 1
+fi
+if ! chmod 700 "$_shim_root"; then
+    echo "zellij-tmux-shim: ERROR: failed to secure state root" >&2
+    unset _shim_root
+    return 1 2>/dev/null || exit 1
+fi
 _owner=$(stat -c '%u' "$_shim_root" 2>/dev/null || stat -f '%u' "$_shim_root" 2>/dev/null)
 if [ "$_owner" != "$(id -u)" ]; then
     echo "zellij-tmux-shim: ERROR: state root not owned by current user" >&2
@@ -65,7 +86,31 @@ if [ "$_owner" != "$(id -u)" ]; then
 fi
 unset _owner
 # Per-session subdir inherits root's 700 protection
-mkdir -p "$ZELLIJ_TMUX_SHIM_STATE"
+case "$ZELLIJ_TMUX_SHIM_STATE" in
+    "$_shim_root"/*) ;;
+    *)
+        echo "zellij-tmux-shim: ERROR: state dir escaped state root" >&2
+        unset _shim_root
+        return 1 2>/dev/null || exit 1
+        ;;
+esac
+if ! mkdir -p "$ZELLIJ_TMUX_SHIM_STATE"; then
+    echo "zellij-tmux-shim: ERROR: failed to create state dir" >&2
+    unset _shim_root
+    return 1 2>/dev/null || exit 1
+fi
+if ! chmod 700 "$ZELLIJ_TMUX_SHIM_STATE"; then
+    echo "zellij-tmux-shim: ERROR: failed to secure state dir" >&2
+    unset _shim_root
+    return 1 2>/dev/null || exit 1
+fi
+_owner=$(stat -c '%u' "$ZELLIJ_TMUX_SHIM_STATE" 2>/dev/null || stat -f '%u' "$ZELLIJ_TMUX_SHIM_STATE" 2>/dev/null)
+if [ "$_owner" != "$(id -u)" ]; then
+    echo "zellij-tmux-shim: ERROR: state dir not owned by current user" >&2
+    unset _shim_root _owner
+    return 1 2>/dev/null || exit 1
+fi
+unset _owner
 unset _shim_root
 
 # Initialize next_id counter (start at 1, %0 is reserved for the host pane)

--- a/bin/tmux
+++ b/bin/tmux
@@ -128,34 +128,6 @@ wait_for_ready() {
     done
 }
 
-# Stack all agent panes together so they share one visual area on the right.
-# With N agents stacked, the layout is always: [main | stacked agents] — a single
-# split point, which makes move-focus reliable regardless of how many agents exist.
-stack_agent_panes() {
-    local my_group="${ZELLIJ_PANE_ID:-0}"
-    local ids=()
-    local id_file pane_key zid pid_file pid group_file
-    for id_file in "${STATE_DIR}"/*.zellij_id; do
-        [ -f "$id_file" ] || return 0
-        pane_key="${id_file##*/}"
-        pane_key="${pane_key%.zellij_id}"
-        # Only include panes from the same tab (matching caller group)
-        group_file="${STATE_DIR}/${pane_key}.group"
-        [ -f "$group_file" ] && [ "$(cat "$group_file" 2>/dev/null)" = "$my_group" ] || continue
-        # Only include panes that have a live process (skip orphaned state)
-        pid_file="${STATE_DIR}/${pane_key}.pid"
-        [ -f "$pid_file" ] || continue
-        pid=$(cat "$pid_file" 2>/dev/null)
-        [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null || continue
-        zid=$(cat "$id_file" 2>/dev/null)
-        [ -n "$zid" ] && [ "$zid" != "unknown" ] && ids+=("$zid")
-    done
-    if [ ${#ids[@]} -ge 2 ]; then
-        zellij action stack-panes -- "${ids[@]}" 2>/dev/null || true
-        log_debug "stack_agent_panes: stacked ${ids[*]}"
-    fi
-}
-
 # Wait for the wrapper to finish renaming the pane.
 # The wrapper touches a .named sentinel after calling rename-pane, which locks
 # the pane title so Claude Code's continuous resets are permanently ignored.
@@ -173,11 +145,6 @@ wait_for_named() {
         fi
         sleep 0.1 2>/dev/null || sleep 1
     done
-}
-
-# Return focus to the main pane (left of agents).
-refocus_main() {
-    zellij action move-focus left 2>/dev/null || true
 }
 
 # Serialize a bash array into a single string preserving argument boundaries.
@@ -251,7 +218,21 @@ display-message)
 
     case "$local_format" in
         '#{pane_id}')
-            echo "${TMUX_PANE:-"%0"}"
+            if [ -n "$local_target" ]; then
+                case "$local_target" in
+                    %*)
+                        target_key="${local_target#%}"
+                        validate_pane_key "$target_key" || exit 1
+                        echo "$local_target"
+                        ;;
+                    *)
+                        log_debug "display-message: unsupported pane target '$local_target'"
+                        echo "${TMUX_PANE:-"%0"}"
+                        ;;
+                esac
+            else
+                echo "${TMUX_PANE:-"%0"}"
+            fi
             ;;
         '#{session_name}:#{window_index}')
             echo "main:0"
@@ -272,20 +253,17 @@ display-message)
 
 # --- split-window ---
 split-window)
-    sw_target=""
     sw_direction="right"
-    sw_size=""
     sw_print=false
-    sw_format=""
     sw_command=()
     while [ $# -gt 0 ]; do
         case "$1" in
-            -t) sw_target="${2:-}"; shift 2 || shift ;;
+            -t) shift 2 || shift ;;
             -h) sw_direction="right"; shift ;;
             -v) sw_direction="down"; shift ;;
-            -l) sw_size="${2:-}"; shift 2 || shift ;;
+            -l) shift 2 || shift ;;
             -P) sw_print=true; shift ;;
-            -F) sw_format="${2:-}"; shift 2 || shift ;;
+            -F) shift 2 || shift ;;
             -d) shift ;;
             --)
                 shift
@@ -433,7 +411,19 @@ send-keys)
         ZELLIJ_ID_FILE="${STATE_DIR}/${PANE_KEY}.zellij_id"
         if [ -f "$ZELLIJ_ID_FILE" ]; then
             log_debug "send-keys: FIFO gone, falling back to write-chars"
-            zellij action write-chars "${COMMAND_TEXT}"$'\n' 2>/dev/null || true
+            zellij_id=$(cat "$ZELLIJ_ID_FILE" 2>/dev/null)
+            if [ -z "$zellij_id" ] || [ "$zellij_id" = "unknown" ]; then
+                log_debug "send-keys: no usable zellij pane id for ${sk_target}"
+                exit 1
+            fi
+            if ! zellij action focus-pane-id "$zellij_id" 2>/dev/null; then
+                log_debug "send-keys: failed to focus zellij pane ${zellij_id}"
+                exit 1
+            fi
+            if ! zellij action write-chars "${COMMAND_TEXT}"$'\n' 2>/dev/null; then
+                log_debug "send-keys: failed to write chars to ${zellij_id}"
+                exit 1
+            fi
         else
             log_debug "send-keys: no FIFO and no zellij_id for ${sk_target}"
         fi
@@ -535,11 +525,10 @@ has-session)
 # --- new-session ---
 new-session)
     ns_name=""
-    ns_detach=false
     ns_command=()
     while [ $# -gt 0 ]; do
         case "$1" in
-            -d) ns_detach=true; shift ;;
+            -d) shift ;;
             -s) ns_name="${2:-}"; shift 2 || shift ;;
             -x|-y) shift 2 || shift ;;
             --)
@@ -566,17 +555,15 @@ new-session)
 
 # --- new-window ---
 new-window)
-    nw_target=""
     nw_name=""
     nw_print=false
-    nw_format=""
     nw_command=()
     while [ $# -gt 0 ]; do
         case "$1" in
-            -t) nw_target="${2:-}"; shift 2 || shift ;;
+            -t) shift 2 || shift ;;
             -n) nw_name="${2:-}"; shift 2 || shift ;;
             -P) nw_print=true; shift ;;
-            -F) nw_format="${2:-}"; shift 2 || shift ;;
+            -F) shift 2 || shift ;;
             -d) shift ;;
             --)
                 shift

--- a/deactivate.sh
+++ b/deactivate.sh
@@ -1,26 +1,47 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2317
 # Source this file to deactivate the zellij-tmux-shim.
 # Usage: source deactivate.sh
 
-if [ -z "$ZELLIJ_TMUX_SHIM_ACTIVE" ]; then
+if [ -z "${ZELLIJ_TMUX_SHIM_ACTIVE:-}" ]; then
     echo "zellij-tmux-shim: not active, nothing to deactivate" >&2
     return 0 2>/dev/null || exit 0
 fi
 
-# Kill any remaining wrapper processes and clean up their panes
-if [ -d "$ZELLIJ_TMUX_SHIM_STATE" ]; then
-    for pidfile in "$ZELLIJ_TMUX_SHIM_STATE"/*.pid; do
+# Kill any remaining wrapper processes and clean up their panes.
+# Refuse cleanup if the state path is not inside the activation-created root.
+_state_dir="${ZELLIJ_TMUX_SHIM_STATE:-}"
+_state_root="${ZELLIJ_TMUX_SHIM_ROOT:-}"
+if [ -n "$_state_dir" ]; then
+    if [ -z "$_state_root" ]; then
+        echo "zellij-tmux-shim: ERROR: state root missing, refusing cleanup" >&2
+        unset _state_dir _state_root
+        return 1 2>/dev/null || exit 1
+    fi
+    case "$_state_dir" in
+        "$_state_root"/*) ;;
+        *)
+            echo "zellij-tmux-shim: ERROR: state dir outside state root, refusing cleanup" >&2
+            unset _state_dir _state_root
+            return 1 2>/dev/null || exit 1
+            ;;
+    esac
+fi
+
+if [ -d "$_state_dir" ]; then
+    for pidfile in "$_state_dir"/*.pid; do
         [ -f "$pidfile" ] || continue
         pid=$(cat "$pidfile" 2>/dev/null)
         if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
             kill "$pid" 2>/dev/null
         fi
     done
-    rm -rf "$ZELLIJ_TMUX_SHIM_STATE"
+    rm -rf "$_state_dir"
 fi
+unset _state_dir _state_root
 
 # Restore original PATH
-if [ -n "$ZELLIJ_TMUX_SHIM_ORIG_PATH" ]; then
+if [ -n "${ZELLIJ_TMUX_SHIM_ORIG_PATH:-}" ]; then
     export PATH="$ZELLIJ_TMUX_SHIM_ORIG_PATH"
 fi
 
@@ -29,6 +50,7 @@ unset TMUX
 unset TMUX_PANE
 unset ZELLIJ_TMUX_SHIM_ACTIVE
 unset ZELLIJ_TMUX_SHIM_DIR
+unset ZELLIJ_TMUX_SHIM_ROOT
 unset ZELLIJ_TMUX_SHIM_STATE
 unset ZELLIJ_TMUX_SHIM_REAL_TMUX
 unset ZELLIJ_TMUX_SHIM_ORIG_PATH

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2030,SC2031
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_TMP="${TMPDIR:-/tmp}/zellij-tmux-shim-tests.$$"
+FAKE_BIN="${TEST_TMP}/bin"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+    rm -rf "$TEST_TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+
+cat > "${FAKE_BIN}/zellij" <<'FAKE_ZELLIJ'
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="${FAKE_ZELLIJ_LOG:?FAKE_ZELLIJ_LOG not set}"
+printf '%s\n' "$*" >> "$LOG_FILE"
+
+if [ "${1:-}" = "action" ] && [ "${2:-}" = "new-pane" ]; then
+    pane_id=""
+    for arg in "$@"; do
+        case "$arg" in
+            %*[0-9])
+                pane_id="$arg"
+                ;;
+        esac
+    done
+    if [ -n "$pane_id" ]; then
+        pane_key="${pane_id#%}"
+        echo "$$" > "${ZELLIJ_TMUX_SHIM_STATE}/${pane_key}.pid"
+        echo "terminal_${pane_key}" > "${ZELLIJ_TMUX_SHIM_STATE}/${pane_key}.zellij_id"
+        touch "${ZELLIJ_TMUX_SHIM_STATE}/${pane_key}.ready"
+    fi
+    echo "terminal_25"
+fi
+FAKE_ZELLIJ
+chmod +x "${FAKE_BIN}/zellij"
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+    if [ "$expected" != "$actual" ]; then
+        echo "FAIL: ${message}" >&2
+        echo "  expected: ${expected}" >&2
+        echo "  actual:   ${actual}" >&2
+        return 1
+    fi
+}
+
+assert_contains() {
+    local needle="$1"
+    local haystack="$2"
+    local message="$3"
+    case "$haystack" in
+        *"$needle"*) ;;
+        *)
+            echo "FAIL: ${message}" >&2
+            echo "  expected to find: ${needle}" >&2
+            echo "  in: ${haystack}" >&2
+            return 1
+            ;;
+    esac
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local haystack="$2"
+    local message="$3"
+    case "$haystack" in
+        *"$needle"*)
+            echo "FAIL: ${message}" >&2
+            echo "  did not expect: ${needle}" >&2
+            echo "  in: ${haystack}" >&2
+            return 1
+            ;;
+        *) ;;
+    esac
+}
+
+run_test() {
+    local name="$1"
+    shift
+    if "$@"; then
+        PASS_COUNT=$((PASS_COUNT + 1))
+        echo "ok - ${name}"
+    else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        echo "not ok - ${name}" >&2
+    fi
+}
+
+test_activate_path_is_idempotent() (
+    local output first count shim_bin
+    output="$(ROOT_DIR="$ROOT_DIR" TEST_TMP="$TEST_TMP" bash -c '
+        set -euo pipefail
+        unset ZELLIJ_TMUX_SHIM_ACTIVE ZELLIJ_TMUX_SHIM_DIR ZELLIJ_TMUX_SHIM_ROOT ZELLIJ_TMUX_SHIM_STATE
+        tmp="${TEST_TMP}/path-idempotent"
+        data="${tmp}/data"
+        run="${tmp}/run"
+        shim_bin="${data}/zellij-tmux-shim/bin"
+        mkdir -p "$shim_bin" "$run"
+        export HOME="$tmp/home"
+        export XDG_DATA_HOME="$data"
+        export XDG_RUNTIME_DIR="$run"
+        export ZELLIJ=1
+        export ZELLIJ_SESSION_NAME="main"
+        export PATH="/usr/bin:/bin"
+        . "${ROOT_DIR}/activate.sh" >/dev/null 2>&1
+        . "${ROOT_DIR}/activate.sh" >/dev/null 2>&1
+        . "${ROOT_DIR}/activate.sh" >/dev/null 2>&1
+        count=0
+        old_ifs="$IFS"
+        IFS=:
+        for part in $PATH; do
+            if [ "$part" = "$shim_bin" ]; then
+                count=$((count + 1))
+            fi
+        done
+        IFS="$old_ifs"
+        printf "%s\n%s\n%s\n" "${PATH%%:*}" "$count" "$shim_bin"
+    ')"
+    first="$(printf '%s\n' "$output" | sed -n '1p')"
+    count="$(printf '%s\n' "$output" | sed -n '2p')"
+    shim_bin="$(printf '%s\n' "$output" | sed -n '3p')"
+    assert_eq "$shim_bin" "$first" "shim bin stays first in PATH" || return 1
+    assert_eq "1" "$count" "shim bin appears only once in PATH" || return 1
+)
+
+test_activate_sanitizes_session_name() (
+    local output expected_root state actual_root
+    output="$(ROOT_DIR="$ROOT_DIR" TEST_TMP="$TEST_TMP" bash -c '
+        set -euo pipefail
+        unset ZELLIJ_TMUX_SHIM_ACTIVE ZELLIJ_TMUX_SHIM_DIR ZELLIJ_TMUX_SHIM_ROOT ZELLIJ_TMUX_SHIM_STATE
+        tmp="${TEST_TMP}/session-sanitize"
+        data="${tmp}/data"
+        run="${tmp}/run"
+        expected_root="${run}/zellij-tmux-shim-$(id -u)"
+        mkdir -p "${data}/zellij-tmux-shim/bin" "$run"
+        export HOME="$tmp/home"
+        export XDG_DATA_HOME="$data"
+        export XDG_RUNTIME_DIR="$run"
+        export ZELLIJ=1
+        export ZELLIJ_SESSION_NAME="../../escaped"
+        export PATH="/usr/bin:/bin"
+        . "${ROOT_DIR}/activate.sh" >/dev/null 2>&1
+        printf "%s\n%s\n%s\n" "$expected_root" "${ZELLIJ_TMUX_SHIM_ROOT:-}" "$ZELLIJ_TMUX_SHIM_STATE"
+    ')"
+    expected_root="$(printf '%s\n' "$output" | sed -n '1p')"
+    actual_root="$(printf '%s\n' "$output" | sed -n '2p')"
+    state="$(printf '%s\n' "$output" | sed -n '3p')"
+    assert_eq "$expected_root" "$actual_root" "activation exports shim root" || return 1
+    case "$state" in
+        "$expected_root"/*) ;;
+        *)
+            echo "FAIL: state dir must stay under shim root" >&2
+            echo "  root:  $expected_root" >&2
+            echo "  state: $state" >&2
+            return 1
+            ;;
+    esac
+    assert_not_contains ".." "${state##*/}" "state basename is sanitized" || return 1
+    assert_not_contains "/" "${state##*/}" "state basename has no slash" || return 1
+)
+
+test_deactivate_refuses_unsafe_state_path() (
+    local tmp="${TEST_TMP}/deactivate-safety"
+    local root="${tmp}/root"
+    local escaped="${tmp}/escaped"
+    mkdir -p "$root" "$escaped"
+    touch "${escaped}/sentinel"
+
+    export ZELLIJ_TMUX_SHIM_ACTIVE=1
+    export ZELLIJ_TMUX_SHIM_ROOT="$root"
+    export ZELLIJ_TMUX_SHIM_STATE="$escaped"
+    export PATH="/usr/bin:/bin"
+
+    set +e
+    . "${ROOT_DIR}/deactivate.sh" >/dev/null 2>&1
+    local code=$?
+    set -e
+
+    if [ "$code" -eq 0 ]; then
+        echo "FAIL: deactivate should fail for state outside shim root" >&2
+        return 1
+    fi
+    if [ ! -f "${escaped}/sentinel" ]; then
+        echo "FAIL: deactivate removed an unsafe state directory" >&2
+        return 1
+    fi
+)
+
+test_split_window_prints_only_tmux_pane_id() (
+    local tmp="${TEST_TMP}/split-window"
+    local state="${tmp}/state"
+    mkdir -p "$state"
+    echo "1" > "${state}/next_id"
+    touch "${state}/sessions"
+
+    export FAKE_ZELLIJ_LOG="${tmp}/zellij.log"
+    export ZELLIJ_TMUX_SHIM_STATE="$state"
+    export ZELLIJ_TMUX_SHIM_DIR="$ROOT_DIR"
+    export PATH="${FAKE_BIN}:/usr/bin:/bin"
+
+    local output
+    output="$("${ROOT_DIR}/bin/tmux" split-window -P -F '#{pane_id}')"
+    assert_eq "%1" "$output" "split-window -P output is not polluted by zellij stdout" || return 1
+)
+
+test_display_message_honors_target_pane() (
+    local tmp="${TEST_TMP}/display-message"
+    local state="${tmp}/state"
+    mkdir -p "$state"
+
+    export ZELLIJ_TMUX_SHIM_STATE="$state"
+    export ZELLIJ_TMUX_SHIM_DIR="$ROOT_DIR"
+    export TMUX_PANE="%0"
+
+    local output
+    output="$("${ROOT_DIR}/bin/tmux" display-message -t %42 -p '#{pane_id}')"
+    assert_eq "%42" "$output" "display-message returns requested target pane id" || return 1
+)
+
+test_send_keys_focuses_target_before_late_write() (
+    local tmp="${TEST_TMP}/late-send-keys"
+    local state="${tmp}/state"
+    mkdir -p "$state"
+    echo "terminal_7" > "${state}/7.zellij_id"
+    echo "$$" > "${state}/7.pid"
+
+    export FAKE_ZELLIJ_LOG="${tmp}/zellij.log"
+    export ZELLIJ_TMUX_SHIM_STATE="$state"
+    export ZELLIJ_TMUX_SHIM_DIR="$ROOT_DIR"
+    export PATH="${FAKE_BIN}:/usr/bin:/bin"
+
+    "${ROOT_DIR}/bin/tmux" send-keys -t %7 "echo hello" Enter
+
+    local log
+    log="$(cat "${tmp}/zellij.log")"
+    assert_contains "action focus-pane-id terminal_7" "$log" "late send-keys focuses target pane" || return 1
+    assert_contains "action write-chars echo hello" "$log" "late send-keys writes after focus" || return 1
+)
+
+run_test "activate PATH re-source is idempotent" test_activate_path_is_idempotent
+run_test "activate sanitizes session-derived state path" test_activate_sanitizes_session_name
+run_test "deactivate refuses unsafe state path" test_deactivate_refuses_unsafe_state_path
+run_test "split-window -P prints only tmux pane id" test_split_window_prints_only_tmux_pane_id
+run_test "display-message honors target pane" test_display_message_honors_target_pane
+run_test "late send-keys focuses target pane before writing" test_send_keys_focuses_target_before_late_write
+
+echo "${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## Summary

- Make activation idempotent without duplicating the shim path.
- Sanitize session-derived runtime state paths and export a trusted shim state root.
- Refuse unsafe deactivate cleanup outside the activation-created state root.
- Focus the recorded Zellij pane before late `send-keys` fallback writes.
- Add a Bash test harness covering the safety and compatibility paths.
- Update README tested Zellij version and development checks.

## Verification

- `bash tests/run.sh` -> 6 passed, 0 failed
- `bash -n activate.sh deactivate.sh install.sh bin/tmux bin/zellij-pane-wrapper tests/run.sh`
- `shellcheck activate.sh deactivate.sh install.sh bin/tmux bin/zellij-pane-wrapper tests/run.sh`
- `git diff --check`
- `zellij --version` -> zellij 0.44.1

Note: `zellij action list-panes` could not be used as a live session smoke test from this shell because there was no active Zellij session.